### PR TITLE
allow to define a custom default response encoder

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,5 +1,7 @@
 package kitty
 
+import kithttp "github.com/go-kit/kit/transport/http"
+
 // Config holds configuration info for kitty.HTTPTransport.
 type Config struct {
 	// LivenessCheckPath is the path of the health handler (default: "/alivez").
@@ -10,6 +12,8 @@ type Config struct {
 	HTTPPort int
 	// EnablePProf enables pprof urls (default: false).
 	EnablePProf bool
+	// EncodeResponse overrides go-kit reponse encoder without to have to pass the encoder to each endpoint, but is still overrided by the endpoint's encoder
+	EncodeResponse kithttp.EncodeResponseFunc
 }
 
 // DefaultConfig defines the default config of kitty.HTTPTransport.
@@ -18,4 +22,5 @@ var DefaultConfig = Config{
 	LivenessCheckPath:  "/alivez",
 	ReadinessCheckPath: "/readyz",
 	EnablePProf:        false,
+	EncodeResponse:     kithttp.EncodeJSONResponse,
 }

--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@ type Config struct {
 	HTTPPort int
 	// EnablePProf enables pprof urls (default: false).
 	EnablePProf bool
-	// EncodeResponse overrides go-kit reponse encoder without to have to pass the encoder to each endpoint, but is still overrided by the endpoint's encoder
+	// EncodeResponse defines the default response encoder for all endpoints (by default: EncodeJSONResponse). It can be overriden for a specific endpoint.
 	EncodeResponse kithttp.EncodeResponseFunc
 }
 

--- a/endpoint.go
+++ b/endpoint.go
@@ -30,7 +30,6 @@ func (t *HTTPTransport) Endpoint(method, path string, ep endpoint.Endpoint, opts
 		path:     path,
 		endpoint: ep,
 		decoder:  kithttp.NopRequestDecoder,
-		encoder:  kithttp.EncodeJSONResponse,
 	}
 	for _, opt := range opts {
 		e = opt(e)

--- a/http.go
+++ b/http.go
@@ -63,7 +63,9 @@ func NewHTTPTransport(cfg Config) *HTTPTransport {
 		t.cfg.ReadinessCheckPath = cfg.ReadinessCheckPath
 	}
 	t.cfg.EnablePProf = cfg.EnablePProf
-	t.cfg.EncodeResponse = cfg.EncodeResponse
+	if cfg.EncodeResponse != nil {
+		t.cfg.EncodeResponse = cfg.EncodeResponse
+	}
 	return t
 }
 

--- a/http.go
+++ b/http.go
@@ -18,8 +18,6 @@ type HTTPTransport struct {
 
 	endpoints []*httpendpoint
 
-	defaultEncodeResponse kithttp.EncodeResponseFunc
-
 	httpmiddleware func(http.Handler) http.Handler
 	mux            Router
 	svr            *http.Server

--- a/http_test.go
+++ b/http_test.go
@@ -26,10 +26,10 @@ func TestEndpointResponseEncode(t *testing.T) {
 	overrideCalled := false
 	HTTPTransport.Endpoint("GET", "/test/default", func(ctx context.Context, r interface{}) (interface{}, error) {
 		defaultCalled = true
-		return "OK", nil
+		return "default response", nil
 	}).Endpoint("GET", "/test/override", func(ctx context.Context, r interface{}) (interface{}, error) {
 		overrideCalled = true
-		return "OK", nil
+		return "override response", nil
 	}, Encoder(func(ctx context.Context, w http.ResponseWriter, r interface{}) error {
 		w.WriteHeader(501)
 		return nil
@@ -48,19 +48,18 @@ func TestEndpointResponseEncode(t *testing.T) {
 			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`{}`))),
 		})
 		if !defaultCalled {
-			t.Log("default endpoint not called")
-			t.Fail()
+			t.Error("default endpoint not called")
 		}
 		if rec.Code != 200 {
-			t.Logf("default HTTP response status expected: %d", rec.Code)
-			t.Fail()
+			t.Errorf("default HTTP response status expected: %d", rec.Code)
 		}
 		body := string(rec.Body.Bytes())
-		if strings.TrimSpace(body) != `"OK"` {
-			t.Logf("different body expected: %s", body)
-			t.Fail()
+		if strings.TrimSpace(body) != `"default response"` {
+			t.Errorf("different body expected: %s", body)
 		}
 	}
+	overrideCalled = false
+	defaultCalled = false
 	{
 		rec := httptest.NewRecorder()
 		HTTPTransport.ServeHTTP(rec, &http.Request{
@@ -72,17 +71,14 @@ func TestEndpointResponseEncode(t *testing.T) {
 			Body: ioutil.NopCloser(bytes.NewBuffer([]byte("OK:override"))),
 		})
 		if !overrideCalled {
-			t.Log("override endpoint not called")
-			t.Fail()
+			t.Error("override endpoint not called")
 		}
 		if rec.Code != 501 {
-			t.Logf("override HTTP response status expected: %d", rec.Code)
-			t.Fail()
+			t.Errorf("override HTTP response status expected: %d", rec.Code)
 		}
 		body := string(rec.Body.Bytes())
 		if body != "" {
-			t.Logf("different body expected: %s", body)
-			t.Fail()
+			t.Errorf("different body expected: %s", body)
 		}
 	}
 }
@@ -100,18 +96,17 @@ func TestDefaultResponseEncode(t *testing.T) {
 	HTTPTransport := NewHTTPTransport(cfg).
 		Endpoint("GET", "/test/override", func(ctx context.Context, r interface{}) (interface{}, error) {
 			overrideCalled = true
-			return "OK", nil
+			return "override response", nil
 		}, Encoder(kithttp.EncodeJSONResponse)).
 		Endpoint("GET", "/test/default", func(ctx context.Context, r interface{}) (interface{}, error) {
 			defaultCalled = true
-			return "OK", nil
+			return "default response", nil
 		})
 	err := HTTPTransport.RegisterEndpoints(func(e endpoint.Endpoint) endpoint.Endpoint {
 		return e
 	})
 	if err != nil {
-		t.Logf("error occurred: %+v", err)
-		t.Fail()
+		t.Errorf("error occurred: %+v", err)
 	}
 	{
 		rec := httptest.NewRecorder()
@@ -124,19 +119,18 @@ func TestDefaultResponseEncode(t *testing.T) {
 			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`{}`))),
 		})
 		if !defaultCalled {
-			t.Log("default endpoint not called")
-			t.Fail()
+			t.Error("default endpoint not called")
 		}
 		if rec.Code != 501 {
-			t.Logf("default HTTP response status expected: %d", rec.Code)
-			t.Fail()
+			t.Errorf("default HTTP response status expected: %d", rec.Code)
 		}
 		body := string(rec.Body.Bytes())
 		if body != "" {
-			t.Logf("different body expected: %s", body)
-			t.Fail()
+			t.Errorf("different body expected: %s", body)
 		}
 	}
+	overrideCalled = false
+	defaultCalled = false
 	{
 		rec := httptest.NewRecorder()
 		HTTPTransport.ServeHTTP(rec, &http.Request{
@@ -148,17 +142,14 @@ func TestDefaultResponseEncode(t *testing.T) {
 			Body: ioutil.NopCloser(bytes.NewBuffer([]byte("OK:override"))),
 		})
 		if !overrideCalled {
-			t.Log("override endpoint not called")
-			t.Fail()
+			t.Error("override endpoint not called")
 		}
 		if rec.Code != 200 {
-			t.Logf("override HTTP response status expected: %d", rec.Code)
-			t.Fail()
+			t.Errorf("override HTTP response status expected: %d", rec.Code)
 		}
 		body := string(rec.Body.Bytes())
-		if strings.TrimSpace(body) != `"OK"` {
-			t.Logf("different body expected: %s", body)
-			t.Fail()
+		if strings.TrimSpace(body) != `"override response"` {
+			t.Errorf("different body expected: %s", body)
 		}
 	}
 }

--- a/http_test.go
+++ b/http_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-type Response struct {
-	status string
-}
-
 func TestEndpointResponseEncode(t *testing.T) {
 	cfg := Config{}
 	HTTPTransport := NewHTTPTransport(cfg)
@@ -42,7 +38,7 @@ func TestEndpointResponseEncode(t *testing.T) {
 		if rec.Code != 200 {
 			t.Errorf("default HTTP response status expected: %d", rec.Code)
 		}
-		body := string(rec.Body.Bytes())
+		body := rec.Body.String()
 		if strings.TrimSpace(body) != `"default response"` {
 			t.Errorf("different body expected: %s", body)
 		}
@@ -59,7 +55,7 @@ func TestEndpointResponseEncode(t *testing.T) {
 		if rec.Code != 501 {
 			t.Errorf("override HTTP response status expected: %d", rec.Code)
 		}
-		body := string(rec.Body.Bytes())
+		body := rec.Body.String()
 		if body != "" {
 			t.Errorf("different body expected: %s", body)
 		}
@@ -95,7 +91,7 @@ func TestDefaultResponseEncode(t *testing.T) {
 	if rec.Code != 501 {
 		t.Errorf("default HTTP response status expected: %d", rec.Code)
 	}
-	body := string(rec.Body.Bytes())
+	body := rec.Body.String()
 	if strings.TrimSpace(body) != `response:"default response"` {
 		t.Errorf("different body expected: %s", body)
 	}

--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,164 @@
+package kitty
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/endpoint"
+
+	kithttp "github.com/go-kit/kit/transport/http"
+)
+
+type Response struct {
+	status string
+}
+
+func TestEndpointResponseEncode(t *testing.T) {
+	cfg := Config{}
+	HTTPTransport := NewHTTPTransport(cfg)
+	defaultCalled := false
+	overrideCalled := false
+	HTTPTransport.Endpoint("GET", "/test/default", func(ctx context.Context, r interface{}) (interface{}, error) {
+		defaultCalled = true
+		return "OK", nil
+	}).Endpoint("GET", "/test/override", func(ctx context.Context, r interface{}) (interface{}, error) {
+		overrideCalled = true
+		return "OK", nil
+	}, Encoder(func(ctx context.Context, w http.ResponseWriter, r interface{}) error {
+		w.WriteHeader(501)
+		return nil
+	}))
+	HTTPTransport.RegisterEndpoints(func(e endpoint.Endpoint) endpoint.Endpoint {
+		return e
+	})
+	{
+		rec := httptest.NewRecorder()
+		HTTPTransport.ServeHTTP(rec, &http.Request{
+			Method:     "GET",
+			RequestURI: "/test/default",
+			URL: &url.URL{
+				Path: "/test/default",
+			},
+			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`{}`))),
+		})
+		if !defaultCalled {
+			t.Log("default endpoint not called")
+			t.Fail()
+		}
+		if rec.Code != 200 {
+			t.Logf("default HTTP response status expected: %d", rec.Code)
+			t.Fail()
+		}
+		body := string(rec.Body.Bytes())
+		if strings.TrimSpace(body) != `"OK"` {
+			t.Logf("different body expected: %s", body)
+			t.Fail()
+		}
+	}
+	{
+		rec := httptest.NewRecorder()
+		HTTPTransport.ServeHTTP(rec, &http.Request{
+			Method:     "GET",
+			RequestURI: "/test/override",
+			URL: &url.URL{
+				Path: "/test/override",
+			},
+			Body: ioutil.NopCloser(bytes.NewBuffer([]byte("OK:override"))),
+		})
+		if !overrideCalled {
+			t.Log("override endpoint not called")
+			t.Fail()
+		}
+		if rec.Code != 501 {
+			t.Logf("override HTTP response status expected: %d", rec.Code)
+			t.Fail()
+		}
+		body := string(rec.Body.Bytes())
+		if body != "" {
+			t.Logf("different body expected: %s", body)
+			t.Fail()
+		}
+	}
+}
+
+func TestDefaultResponseEncode(t *testing.T) {
+	cfg := Config{
+		EncodeResponse: func(ctx context.Context, w http.ResponseWriter, r interface{}) error {
+			w.WriteHeader(501)
+			return nil
+		},
+	}
+
+	defaultCalled := false
+	overrideCalled := false
+	HTTPTransport := NewHTTPTransport(cfg).
+		Endpoint("GET", "/test/override", func(ctx context.Context, r interface{}) (interface{}, error) {
+			overrideCalled = true
+			return "OK", nil
+		}, Encoder(kithttp.EncodeJSONResponse)).
+		Endpoint("GET", "/test/default", func(ctx context.Context, r interface{}) (interface{}, error) {
+			defaultCalled = true
+			return "OK", nil
+		})
+	err := HTTPTransport.RegisterEndpoints(func(e endpoint.Endpoint) endpoint.Endpoint {
+		return e
+	})
+	if err != nil {
+		t.Logf("error occurred: %+v", err)
+		t.Fail()
+	}
+	{
+		rec := httptest.NewRecorder()
+		HTTPTransport.ServeHTTP(rec, &http.Request{
+			Method:     "GET",
+			RequestURI: "/test/default",
+			URL: &url.URL{
+				Path: "/test/default",
+			},
+			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(`{}`))),
+		})
+		if !defaultCalled {
+			t.Log("default endpoint not called")
+			t.Fail()
+		}
+		if rec.Code != 501 {
+			t.Logf("default HTTP response status expected: %d", rec.Code)
+			t.Fail()
+		}
+		body := string(rec.Body.Bytes())
+		if body != "" {
+			t.Logf("different body expected: %s", body)
+			t.Fail()
+		}
+	}
+	{
+		rec := httptest.NewRecorder()
+		HTTPTransport.ServeHTTP(rec, &http.Request{
+			Method:     "GET",
+			RequestURI: "/test/override",
+			URL: &url.URL{
+				Path: "/test/override",
+			},
+			Body: ioutil.NopCloser(bytes.NewBuffer([]byte("OK:override"))),
+		})
+		if !overrideCalled {
+			t.Log("override endpoint not called")
+			t.Fail()
+		}
+		if rec.Code != 200 {
+			t.Logf("override HTTP response status expected: %d", rec.Code)
+			t.Fail()
+		}
+		body := string(rec.Body.Bytes())
+		if strings.TrimSpace(body) != `"OK"` {
+			t.Logf("different body expected: %s", body)
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
The default go-kit JSON encoder could be override in the configuration of kitty HTTP transport, so we don't pass the same encoder at each endpoint, but still be able to override it from the endpoint as option.