### PR TITLE
Prepare release v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: go
 
 go:
-  - 1.9.x
+  - 1.11.x
   - 1.12.x
   - 1.13.x
-  - 1.x
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 
 `go get github.com/objenious/kitty`
 
-## Status: beta - breaking changes might happen
-
-*Warning: Breaking changes in 0.0.4, with the addition of transports*
-
 Kitty is a slightly opinionated framework based on go-kit.
 It's goal is to ease development of microservices deployed on Kubernetes (or any similar orchestration platform).
 
@@ -112,7 +108,7 @@ err := kitty.NewServer(tr).Run(ctx)
 
 ## Requirements
 
-Go > 1.8
+Go > 1.11
 
 ## Contribution guidelines
 


### PR DESCRIPTION
The project is stable enough and not really subject to breaking changes now. I think it's about time we release a v1.

Also, for our own sanity as maintainers, we should probably limit the number of go version supported. I think having at max the current release minus two is a good idea. (eg: 1.13->1.11)