### PR TITLE
Add a client that doesn't deal with HTTP Errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -28,6 +28,17 @@ func NewClient(
 	return &Client{Client: kithttp.NewClient(method, tgt, enc, makeDecodeResponseFunc(dec), options...)}
 }
 
+// NewClientWithError creates a kitty client that decode error.
+func NewClientWithError(
+	method string,
+	tgt *url.URL,
+	enc kithttp.EncodeRequestFunc,
+	dec kithttp.DecodeResponseFunc,
+	options ...kithttp.ClientOption,
+) *Client {
+	return &Client{Client: kithttp.NewClient(method, tgt, enc, dec, options...)}
+}
+
 // makeDecodeResponseFunc maps HTTP errors to Go errors.
 func makeDecodeResponseFunc(fn kithttp.DecodeResponseFunc) kithttp.DecodeResponseFunc {
 	return func(ctx context.Context, resp *http.Response) (interface{}, error) {

--- a/client.go
+++ b/client.go
@@ -28,7 +28,8 @@ func NewClient(
 	return &Client{Client: kithttp.NewClient(method, tgt, enc, makeDecodeResponseFunc(dec), options...)}
 }
 
-// NewClientWithError creates a kitty client that decode error.
+// NewClientWithError creates a kitty client that doesn't deal with HTTP errors.
+// and let you do it while you decode.
 func NewClientWithError(
 	method string,
 	tgt *url.URL,

--- a/client_test.go
+++ b/client_test.go
@@ -45,6 +45,58 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestClientWithError(t *testing.T) {
+	h := testHandler{}
+	ts := httptest.NewServer(&h)
+	defer ts.Close()
+
+	client := ts.Client()
+	u, _ := url.Parse(ts.URL)
+	e := NewClientWithError("GET", u, kithttp.EncodeJSONRequest, decodeTestResponse, kithttp.SetClient(client)).Endpoint()
+
+	h.statuses = []int{http.StatusServiceUnavailable}
+	resp, err := e(context.TODO(), nil)
+	if err != nil {
+		t.Error("When calling a failed server, the client with error should NOT return an error")
+	}
+	v, ok := resp.(testStruct)
+	if ok == false {
+		t.Errorf("The returned response must be decoded, got %#v", resp)
+	}
+	if v.err == nil {
+		t.Error("The response has not been correctly decoded")
+	}
+
+	if !IsRetryable(v.err) {
+		t.Error("The returned error for http.StatusServiceUnavailable should be retryable")
+	}
+
+	h.statuses = []int{http.StatusBadRequest}
+	resp, err = e(context.TODO(), nil)
+	if err != nil {
+		t.Error("When calling a failed server, the client with error should NOT return an error")
+	}
+	v, ok = resp.(testStruct)
+	if ok == false {
+		t.Errorf("The returned response must be decoded, got %#v", resp)
+	}
+	if v.err == nil {
+		t.Error("The response has not been correctly decoded")
+	}
+	if IsRetryable(v.err) {
+		t.Error("The returned error for http.StatusBadRequest should not be retryable")
+	}
+
+
+	h.statuses = []int{}
+	res, err := e(context.TODO(), nil)
+	if err != nil {
+		t.Errorf("When calling a working server, the client should not return an error, got %s", err)
+	} else if !reflect.DeepEqual(res, testData) {
+		t.Errorf("The endpoint returned invalid data : %+v", res)
+	}
+}
+
 var testData = testStruct{Foo: "bar"}
 
 type testHandler struct {
@@ -57,8 +109,8 @@ func (h *testHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 		h.statuses = h.statuses[1:]
 	} else {
 		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(testData)
 	}
+	json.NewEncoder(w).Encode(testData)
 }
 
 func decodeTestResponse(ctx context.Context, resp *http.Response) (interface{}, error) {
@@ -66,5 +118,8 @@ func decodeTestResponse(ctx context.Context, resp *http.Response) (interface{}, 
 	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
 		return nil, err
 	}
+
+	response.err = HTTPError(resp)
+
 	return response, nil
 }

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/go-logfmt/logfmt v0.4.0 h1:MP4Eh7ZCb31lleYCFuwm0oe4/YGak+5l1vA2NOE80n
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj2vyii2bbUNDw3kt9VxK2EY=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sony/gobreaker v0.4.1 h1:oMnRNZXX5j85zso6xCPRNPtmAycat+WcoKbklScLDgQ=

--- a/server_test.go
+++ b/server_test.go
@@ -105,6 +105,8 @@ func TestServer(t *testing.T) {
 type testStruct struct {
 	Foo    string `json:"foo"`
 	Status int    `json:"status"`
+
+	err    error
 }
 
 func testEP(_ context.Context, req interface{}) (interface{}, error) {


### PR DESCRIPTION
In some case, you might want to decode the error message returned by an HTTP server. In the current implementation of the client, when a HTTP error is catch by the decoder, it skips the decoding and return directly the HTTPError. With this version, the client will have to deal with the HTTP Error while decoding.